### PR TITLE
update: address the usage of 'acceptable_engine_tag' and correct typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ nexport.export(
 ```
 `model`: **Required**. A PyTorch model instance.
 
-`acceptable_engine_tag`: **Required**. A string version number indicates the acceptable inference engine release. Since nexport generates the json file that is highly tied to the inference engine, the json keywords may subject to change whenever something happen on inference engine. 
+`acceptable_engine_tag`: **Required**. A string version number indicates an acceptable inference engine release. Because nexport generates a JSON file that is intimately tied to Inference-Engine, the JSON keywords may change when Inference-Engine's file format changes. 
 The is why this parameter is here to indicate the version track of inference engine.
 
 `file_type`: **Required**. Mandatory to put `json_exp` for now

--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ nexport.export(
               include_metadata=True, model_name="YOUR_PYTORCH_MODEL_NAME", model_author="YOUR_PYTORCH_MODEL_AUTHOR", activation_function="gelu",
               using_skip_connections=False)
 ```
-`model`: **Required**. A pytroch model instance.
+`model`: **Required**. A PyTorch model instance.
+
+`acceptable_engine_tag`: **Required**. A string version number indicates the acceptable inference engine release. Since nexport generates the json file that is highly tied to the inference engine, the json keywords may subject to change whenever something happen on inference engine. 
+The is why this parameter is here to indicate the version track of inference engine.
 
 `file_type`: **Required**. Mandatory to put `json_exp` for now
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ nexport.export(
 `model`: **Required**. A PyTorch model instance.
 
 `acceptable_engine_tag`: **Required**. A string version number indicates an acceptable inference engine release. Because nexport generates a JSON file that is intimately tied to Inference-Engine, the JSON keywords may change when Inference-Engine's file format changes. 
-The is why this parameter is here to indicate the version track of inference engine.
+This parameter indicates an Inference-Engine `git` tag known to be able to read and write the nexport output.  Other Inference-Engine revisions might also be compatible.
 
 `file_type`: **Required**. Mandatory to put `json_exp` for now
 


### PR DESCRIPTION
- Correct typo: 'pytroch'->'PyTorch' in README.md
- Address the 'acceptable_engine_tag' usage in README.md